### PR TITLE
Add product manager agent with web search integration

### DIFF
--- a/agents/game-tester/main.py
+++ b/agents/game-tester/main.py
@@ -17,6 +17,7 @@ SYSTEM_PROMPT = """
 You are a game tester.
 You are in a chat room with other humans & agents:
 - CEO
+- product-manager
 - swe-agent
 You can address them by using @, e.g @swe-agent
 Otherwise you will be speaking to everyone.

--- a/agents/product-manager/Makefile
+++ b/agents/product-manager/Makefile
@@ -1,0 +1,4 @@
+dev:
+uv run uvicorn main:app --host 0.0.0.0 --port 8003 --reload
+
+.PHONY: dev

--- a/agents/product-manager/main.py
+++ b/agents/product-manager/main.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from dotenv import load_dotenv
+from duckduckgo_search import DDGS
+from pydantic_ai import Agent, RunContext
+
+load_dotenv()
+
+SYSTEM_PROMPT = """
+You are a product manager.
+You are in a chat room with other humans & agents:
+- CEO
+- swe-agent
+- game-tester
+You can address them by using @, e.g @swe-agent
+Otherwise you will be speaking to everyone.
+Everyone sees all messages.
+You will collaborate on a task to build a game given by the CEO.
+
+Approach each request with a product strategy mindset:
+- Clarify the desired player outcomes, business goals, and success metrics.
+- Coordinate requirements across engineering and QA, highlighting trade-offs and next steps.
+- When more context is needed, ask concise follow-up questions.
+- Keep updates structured with key decisions, open questions, and recommended actions.
+
+You can use the `search_web` tool to perform quick market or reference research. Summarize findings and cite sources inline.
+"""
+
+
+agent = Agent("openai:gpt-4.1", instructions=SYSTEM_PROMPT)
+
+
+@agent.tool
+async def search_web(
+    _ctx: RunContext[None],
+    query: str,
+    max_results: int = 5,
+) -> str:
+    """Search the web for product insights and summarize the top findings."""
+
+    cleaned_query = query.strip()
+    if not cleaned_query:
+        return "Please provide a non-empty search query."
+
+    limit = max(1, min(max_results, 10))
+
+    def _perform_search() -> list[dict[str, Any]]:
+        with DDGS() as ddgs:
+            return list(ddgs.text(cleaned_query, max_results=limit))
+
+    try:
+        results = await asyncio.to_thread(_perform_search)
+    except Exception as exc:  # pragma: no cover - network/runtime guard
+        return f"Web search failed: {exc}"
+
+    if not results:
+        return "No search results were found for that query."
+
+    lines: list[str] = [f"Top {len(results)} results for: {cleaned_query}"]
+    for idx, item in enumerate(results, start=1):
+        title = item.get("title") or "(no title)"
+        url = item.get("href") or "(no url)"
+        snippet = (item.get("body") or "").strip()
+        if snippet:
+            snippet = snippet.replace("\n", " ")
+        lines.append(f"{idx}. {title}\n   URL: {url}")
+        if snippet:
+            lines.append(f"   Notes: {snippet}")
+
+    return "\n".join(lines)
+
+
+app = agent.to_a2a()

--- a/agents/product-manager/pyproject.toml
+++ b/agents/product-manager/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "product-manager"
+version = "0.1.0"
+description = "Product Manager Agent"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "duckduckgo-search>=6.2.0",
+    "fasta2a>=0.5.0",
+    "pydantic-ai>=1.0.10",
+    "python-dotenv>=1.1.1",
+]

--- a/agents/swe-agent/main.py
+++ b/agents/swe-agent/main.py
@@ -23,6 +23,7 @@ SYSTEM_PROMPT = """You are a Software Engineer.
     You are in a chat room with other humans & agents:
     - CEO
     - game-tester
+    - product-manager
     You can address them by using @, e.g @game-tester
     Otherwise you will be speaking to everyone.
     Everyone sees all messages.

--- a/coordinator/src/coordinator_app/registry.py
+++ b/coordinator/src/coordinator_app/registry.py
@@ -12,6 +12,7 @@ class AgentRegistry:
         self.agents = [
             {"name": "game-tester", "url": "http://localhost:8001", "emoji": "🎮"},
             {"name": "swe-agent", "url": "http://localhost:8002", "emoji": "👨‍💻"},
+            {"name": "product-manager", "url": "http://localhost:8003", "emoji": "📋"},
         ]
 
     def get_all_agents(self):

--- a/coordinator/src/coordinator_app/ui.py
+++ b/coordinator/src/coordinator_app/ui.py
@@ -146,6 +146,7 @@ def render_ui() -> str:
                     agentEmojis = {
                         'user': '👤',
                         'game-tester': '🎮',
+                        'product-manager': '📋',
                         'swe-agent': '👨‍💻',
                         'coordinator': '🎯'
                     };


### PR DESCRIPTION
## Summary
- add a product-manager agent with product-focused system prompt and a DuckDuckGo-powered `search_web` tool
- register the new agent with the coordinator, including fallback emoji support in the UI
- update existing agent prompts so the team acknowledges the product manager participant

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cebc4bd57c832aa90d16c6b5b7167e