### PR TITLE
Add game server scaffolding with ngrok tunnel helper

### DIFF
--- a/game-server/README.md
+++ b/game-server/README.md
@@ -1,0 +1,81 @@
+# Game server
+
+This folder contains a lightweight static experience that you can embed inside other
+interfaces. The HTML entry point is `index.html` and the `run_server.py` helper wraps the
+Python standard library HTTP server while adding ngrok tunnelling helpers so that you can
+expose the content behind an HTTPS URL that works inside an `<iframe>`.
+
+## Running locally
+
+```bash
+uv run python game-server/run_server.py
+```
+
+By default the command serves the `game-server` directory on <http://0.0.0.0:8000/> and
+attempts to start an ngrok tunnel by executing `ngrok http {port}`. The ngrok process
+output is streamed with a `[ngrok]` prefix so you can copy the generated public URL.
+
+### Command line options
+
+The helper script includes several switches that make it easier to fit into your
+workflow:
+
+| Flag | Description |
+| --- | --- |
+| `--directory PATH` | Serve a different directory (useful when you replace the sample UI). |
+| `--port PORT` | Change the local port. |
+| `--host HOST` | Override the bind address; defaults to `0.0.0.0`. |
+| `--no-ngrok` | Skip launching ngrok and only serve the local HTTP endpoint. |
+| `--ngrok-template STRING` | Provide a custom command template. `{port}` is replaced with the selected port. |
+| `--ngrok-extra ARG [ARG ...]` | Append extra arguments to the ngrok command. |
+| `--open-browser` | Open the served page in your default browser once the server is ready. |
+
+If ngrok is not installed or the executable lives under a different name, point the
+`--ngrok-template` flag at the correct binary. For example:
+
+```bash
+uv run python game-server/run_server.py --ngrok-template "/opt/ngrok/bin/ngrok http {port}"
+```
+
+Any additional arguments that the ngrok CLI expects (such as region selection or
+authentication tokens) can be appended with `--ngrok-extra`. The template and extra
+arguments give you enough flexibility to match the conventions outlined in the ngrok
+documentation.
+
+## Exposing the server via ngrok
+
+Make sure you have an ngrok account and have installed the CLI on your machine. Export
+any authentication token it requires (for example `NGROK_AUTHTOKEN`) following the official
+documentation, then run the helper:
+
+```bash
+uv run python game-server/run_server.py --ngrok-extra --label example
+```
+
+Watch the console for a line similar to:
+
+```
+[ngrok] https://your-subdomain.ngrok.io -> http://localhost:8000
+```
+
+Use that URL as the `src` of your iframe inside the other UI:
+
+```html
+<iframe src="https://your-subdomain.ngrok.io" width="100%" height="720" allow="fullscreen" style="border:0"></iframe>
+```
+
+The server removes `X-Frame-Options` and applies basic cache busting headers, so the page
+can be embedded safely while you iterate. If you want to run without tunnelling (for
+instance when debugging locally), add `--no-ngrok` or run a plain `python -m
+http.server` inside this folder.
+
+## Customising the UI
+
+`index.html` currently ships with a small animated scoreboard. Replace this file with your
+own HTML/CSS/JavaScript to render the real game interface—`run_server.py` automatically
+serves whatever is inside the target directory. Because the helper uses the standard
+library web server there is no build step; simply refresh the iframe and the changes will
+appear immediately.
+
+> **Tip:** If the iframe host enforces HTTPS you should keep using the ngrok tunnel even
+> when everything runs on the same development machine. That avoids mixed-content issues.

--- a/game-server/index.html
+++ b/game-server/index.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>McPeeps Game Server</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+        --bg: #0f172a;
+        --bg-light: #1e293b;
+        --fg: #e2e8f0;
+        --fg-dark: #1f2937;
+        --accent: #38bdf8;
+        --accent-strong: #0ea5e9;
+        --muted: rgba(148, 163, 184, 0.8);
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: linear-gradient(160deg, rgba(56, 189, 248, 0.12), rgba(99, 102, 241, 0.12)), var(--bg);
+        color: var(--fg);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 3rem 1.5rem;
+      }
+
+      .panel {
+        background: rgba(15, 23, 42, 0.72);
+        border: 1px solid rgba(148, 163, 184, 0.15);
+        border-radius: 24px;
+        backdrop-filter: blur(16px);
+        max-width: 960px;
+        width: min(100%, 960px);
+        padding: clamp(2.5rem, 4vw, 3.5rem);
+        box-shadow: 0 32px 80px rgba(15, 23, 42, 0.4);
+      }
+
+      header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        margin-bottom: 2.5rem;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(2.5rem, 4vw, 3.25rem);
+        font-weight: 700;
+        letter-spacing: -0.02em;
+      }
+
+      header p {
+        margin: 0;
+        font-size: 1.1rem;
+        color: var(--muted);
+      }
+
+      .content {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: clamp(1.25rem, 3vw, 2rem);
+        margin-bottom: 2rem;
+      }
+
+      .card {
+        background: rgba(30, 41, 59, 0.65);
+        border: 1px solid rgba(148, 163, 184, 0.1);
+        border-radius: 18px;
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.1);
+      }
+
+      .card h2 {
+        margin: 0 0 0.75rem;
+        font-size: 1.3rem;
+        color: var(--accent);
+        letter-spacing: -0.01em;
+      }
+
+      .scoreboard {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .player {
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        gap: 0.75rem;
+        align-items: center;
+        background: rgba(15, 23, 42, 0.45);
+        border-radius: 12px;
+        padding: 0.85rem 1rem;
+        box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.08);
+      }
+
+      .player .badge {
+        width: 36px;
+        height: 36px;
+        border-radius: 12px;
+        background: linear-gradient(145deg, rgba(56, 189, 248, 0.65), rgba(59, 130, 246, 0.65));
+        display: grid;
+        place-items: center;
+        font-weight: 600;
+        color: var(--fg-dark);
+      }
+
+      .player .name {
+        font-weight: 600;
+        letter-spacing: 0.01em;
+      }
+
+      .player .score {
+        font-variant-numeric: tabular-nums;
+        font-weight: 700;
+      }
+
+      .status {
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .status .tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.95rem;
+        background: rgba(14, 165, 233, 0.18);
+        border-radius: 999px;
+        padding: 0.4rem 0.85rem;
+        color: rgba(224, 242, 254, 0.92);
+      }
+
+      .status .tag::before {
+        content: "";
+        display: inline-block;
+        width: 0.6rem;
+        height: 0.6rem;
+        border-radius: 50%;
+        background: #22d3ee;
+        box-shadow: 0 0 12px rgba(34, 211, 238, 0.65);
+      }
+
+      footer {
+        font-size: 0.9rem;
+        color: var(--muted);
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.6rem;
+      }
+
+      footer code {
+        font-size: 0.85rem;
+        padding: 0.25rem 0.5rem;
+        border-radius: 6px;
+        background: rgba(148, 163, 184, 0.18);
+        color: var(--fg);
+      }
+
+      @media (max-width: 640px) {
+        .panel {
+          padding: 2rem 1.5rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="panel">
+      <header>
+        <h1>McPeeps Game Server</h1>
+        <p>
+          This lightweight server ships with iframe-friendly defaults so you can embed it
+          in dashboards or other localhost tooling. Swap this markup for your actual game
+          UI and keep using <code>run_server.py</code> to host and tunnel it.
+        </p>
+      </header>
+
+      <div class="content">
+        <section class="card">
+          <h2>Live scoreboard</h2>
+          <div class="scoreboard" id="scoreboard"></div>
+        </section>
+
+        <section class="card status">
+          <h2>Server status</h2>
+          <div class="tag" id="status-tag">starting…</div>
+          <p>
+            The JavaScript below simulates score updates so you can see how dynamic content
+            looks when the page is embedded. Replace it with your own networking code when
+            you hook up a real backend.
+          </p>
+        </section>
+      </div>
+
+      <footer>
+        <span>Serve locally:</span>
+        <code>python run_server.py</code>
+        <span>• Tunnel with Hgrok to iframe across hosts.</span>
+      </footer>
+    </div>
+
+    <script>
+      const players = [
+        { name: "Puffin", score: 73 },
+        { name: "Otter", score: 66 },
+        { name: "Penguin", score: 58 },
+        { name: "Narwhal", score: 41 }
+      ];
+
+      const scoreboard = document.getElementById("scoreboard");
+      const statusTag = document.getElementById("status-tag");
+
+      function render() {
+        scoreboard.innerHTML = "";
+        players
+          .slice()
+          .sort((a, b) => b.score - a.score)
+          .forEach((player, index) => {
+            const wrapper = document.createElement("div");
+            wrapper.className = "player";
+            wrapper.innerHTML = `
+              <span class="badge">${index + 1}</span>
+              <span class="name">${player.name}</span>
+              <span class="score">${player.score}</span>
+            `;
+            scoreboard.appendChild(wrapper);
+          });
+      }
+
+      function tick() {
+        const randomPlayer = players[Math.floor(Math.random() * players.length)];
+        randomPlayer.score += Math.floor(Math.random() * 6);
+        render();
+      }
+
+      setTimeout(() => {
+        statusTag.textContent = "ready for connections";
+      }, 400);
+
+      render();
+      setInterval(tick, 3200);
+    </script>
+  </body>
+</html>

--- a/game-server/run_server.py
+++ b/game-server/run_server.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Serve the local game UI and optionally expose it through ngrok."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import time
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Iterable
+
+SERVER_SHUTDOWN_POLL_SECONDS = 0.2
+
+
+class IframeFriendlyHandler(SimpleHTTPRequestHandler):
+    """HTTP handler that adds headers suitable for iframe embedding."""
+
+    def __init__(self, *args, directory: str | None = None, **kwargs) -> None:
+        super().__init__(*args, directory=directory, **kwargs)
+
+    def end_headers(self) -> None:  # type: ignore[override]
+        # Cache headers keep things fresh during development.
+        self.send_header("Cache-Control", "no-store, must-revalidate")
+        self.send_header("Pragma", "no-cache")
+        # Allow the page to be embedded by other origins.
+        self.send_header("X-Frame-Options", "ALLOWALL")
+        # Make MIME type sniffing less likely to break the iframe.
+        self.send_header("X-Content-Type-Options", "nosniff")
+        super().end_headers()
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the local game server and (optionally) tunnel it with ngrok.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    default_dir = Path(__file__).resolve().parent
+    parser.add_argument(
+        "--directory",
+        type=Path,
+        default=default_dir,
+        help="Directory to serve. Defaults to the game-server folder.",
+    )
+    parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        help="Host interface to bind the HTTP server to.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Local port used for the HTTP server.",
+    )
+    parser.add_argument(
+        "--no-ngrok",
+        action="store_true",
+        help="Skip launching ngrok and only serve locally.",
+    )
+    parser.add_argument(
+        "--ngrok-template",
+        default="ngrok http {port}",
+        help=(
+            "Command template used to start ngrok. The string is formatted with the local port "
+            "(e.g. 'ngrok http 127.0.0.1:{port}')."
+        ),
+    )
+    parser.add_argument(
+        "--ngrok-extra",
+        nargs="*",
+        default=(),
+        help="Additional arguments appended to the ngrok command after template expansion.",
+    )
+    parser.add_argument(
+        "--open-browser",
+        action="store_true",
+        help="Open the served page in the default browser after startup.",
+    )
+    return parser.parse_args()
+
+
+def ensure_directory(directory: Path) -> Path:
+    directory = directory.expanduser().resolve()
+    if not directory.exists():
+        raise FileNotFoundError(f"Directory '{directory}' does not exist.")
+    if not directory.is_dir():
+        raise NotADirectoryError(f"'{directory}' is not a directory.")
+    return directory
+
+
+def start_http_server(host: str, port: int, directory: Path) -> ThreadingHTTPServer:
+    handler = partial(IframeFriendlyHandler, directory=str(directory))
+    try:
+        httpd = ThreadingHTTPServer((host, port), handler)
+    except OSError as exc:  # pragma: no cover - networking edge case
+        print(f"[server] Failed to bind {host}:{port} -> {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+    thread = threading.Thread(target=httpd.serve_forever, name="http-server", daemon=True)
+    thread.start()
+    return httpd
+
+
+def resolve_executable(command: str) -> str | None:
+    path = Path(command)
+    if path.exists():
+        return str(path.resolve())
+    return shutil.which(command)
+
+
+def build_ngrok_command(template: str, port: int, extra_args: Iterable[str]) -> list[str]:
+    try:
+        rendered = template.format(port=port)
+    except KeyError as exc:  # pragma: no cover - runtime misconfiguration
+        print(f"[ngrok] Could not format template: missing key {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+    parts = shlex.split(rendered)
+    if not parts:
+        print("[ngrok] The command template produced an empty command.", file=sys.stderr)
+        raise SystemExit(2)
+
+    executable = resolve_executable(parts[0])
+    if executable is None:
+        print(
+            f"[ngrok] Could not find executable '{parts[0]}'. Set --ngrok-template to the correct binary.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+    parts[0] = executable
+    return [*parts, *extra_args]
+
+
+def stream_subprocess_output(prefix: str, process: subprocess.Popen[str]) -> None:
+    assert process.stdout is not None
+    for line in process.stdout:
+        print(f"[{prefix}] {line.rstrip()}")
+
+
+def launch_ngrok(command: list[str]) -> subprocess.Popen[str] | None:
+    try:
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+    except FileNotFoundError:  # pragma: no cover - handled earlier
+        return None
+
+    thread = threading.Thread(target=stream_subprocess_output, args=("ngrok", process), daemon=True)
+    thread.start()
+    return process
+
+
+def wait_for_interrupt(httpd: ThreadingHTTPServer, ngrok_process: subprocess.Popen[str] | None) -> None:
+    try:
+        while True:
+            time.sleep(SERVER_SHUTDOWN_POLL_SECONDS)
+            if ngrok_process and ngrok_process.poll() is not None:
+                print("[ngrok] Tunnel process exited. Press Ctrl+C to stop the server.")
+                ngrok_process = None
+    except KeyboardInterrupt:
+        print("\n[server] Caught interrupt, shutting down…")
+    finally:
+        httpd.shutdown()
+        if ngrok_process and ngrok_process.poll() is None:
+            with contextlib.suppress(ProcessLookupError):
+                ngrok_process.send_signal(signal.SIGINT)
+            try:
+                ngrok_process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                ngrok_process.kill()
+
+
+
+def maybe_open_browser(host: str, port: int) -> None:
+    try:
+        import webbrowser
+    except Exception as exc:  # pragma: no cover - extremely unlikely
+        print(f"[server] Could not open browser automatically: {exc}")
+        return
+
+    url = f"http://{host}:{port}/"
+    opened = webbrowser.open(url, new=2)
+    if opened:
+        print(f"[server] Opened {url} in your browser.")
+    else:
+        print(f"[server] Please open {url} manually.")
+
+
+
+def main() -> None:
+    args = parse_arguments()
+    directory = ensure_directory(args.directory)
+
+    httpd = start_http_server(args.host, args.port, directory)
+    print(f"[server] Serving {directory} at http://{args.host}:{args.port}/")
+
+    ngrok_process: subprocess.Popen[str] | None = None
+    if not args.no_ngrok:
+        command = build_ngrok_command(args.ngrok_template, args.port, args.ngrok_extra)
+        print(f"[ngrok] Launching: {' '.join(shlex.quote(part) for part in command)}")
+        ngrok_process = launch_ngrok(command)
+        if ngrok_process is None:
+            print("[ngrok] Failed to start the ngrok process.", file=sys.stderr)
+
+    if args.open_browser:
+        maybe_open_browser(args.host if args.host != "0.0.0.0" else "127.0.0.1", args.port)
+
+    wait_for_interrupt(httpd, ngrok_process)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a top-level `game-server` folder with a static scoreboard UI that is safe to iframe
- provide `run_server.py` to serve the folder locally and launch an ngrok tunnel with customizable options
- document how to use the helper script and tunnel URL inside other interfaces, updating references to ngrok

## Testing
- python -m compileall game-server/run_server.py

------
https://chatgpt.com/codex/tasks/task_e_68cebc99f6a8832ab7428275f1120d32