### PR TITLE
Force Nuxt UI to use light color mode

### DIFF
--- a/ui-nuxt/nuxt.config.ts
+++ b/ui-nuxt/nuxt.config.ts
@@ -14,4 +14,9 @@ export default defineNuxtConfig({
     }
   },
   css: ['~/assets/css/main.css'],
+  colorMode: {
+    preference: 'light',
+    fallback: 'light',
+    storageKey: 'nuxt-color-mode-preference',
+  },
 })


### PR DESCRIPTION
## Summary
- configure the Nuxt color mode module to always prefer the light theme
- change the color mode storage key so any prior dark preference is ignored on reload

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68cecee2587c832aa4583731d6bf33eb